### PR TITLE
Use .ts extension in TypeScript imports

### DIFF
--- a/spiceflow/scripts/bun-play.ts
+++ b/spiceflow/scripts/bun-play.ts
@@ -1,4 +1,4 @@
-import { Spiceflow } from '../src/spiceflow.js'
+import { Spiceflow } from '../src/spiceflow.ts'
 
 const app = new Spiceflow()
   .get('/', () => {

--- a/spiceflow/scripts/example-app.ts
+++ b/spiceflow/scripts/example-app.ts
@@ -1,6 +1,6 @@
 import { Spiceflow } from '../src'
 import { z } from 'zod'
-import { openapi } from '../src/openapi.js'
+import { openapi } from '../src/openapi.ts'
 
 const app = new Spiceflow()
   .use(

--- a/spiceflow/scripts/openapi-fern.ts
+++ b/spiceflow/scripts/openapi-fern.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import yaml from 'js-yaml'
 
 import { createSpiceflowClient } from '../src/client'
-import { app } from './example-app.js'
+import { app } from './example-app.ts'
 
 async function main() {
   console.log('Creating Spiceflow client...')

--- a/spiceflow/scripts/play-sdk.vite.ts
+++ b/spiceflow/scripts/play-sdk.vite.ts
@@ -7,7 +7,7 @@ export default defineConfig({
       entry: './scripts/play-sdk.ts',
       formats: ['es'],
 
-      fileName: () => 'play-sdk.js',
+      fileName: () => 'play-sdk.ts',
     },
     rollupOptions: {
       external: ['node-fetch'],

--- a/spiceflow/src/client.test.ts
+++ b/spiceflow/src/client.test.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
-import { createSpiceflowClient } from './client/index.js'
-import { Spiceflow } from './spiceflow.js'
+import { createSpiceflowClient } from './client/index.ts'
+import { Spiceflow } from './spiceflow.ts'
 
 import { describe, expect, it } from 'vitest'
 const app = new Spiceflow()

--- a/spiceflow/src/client/index.ts
+++ b/spiceflow/src/client/index.ts
@@ -1,17 +1,17 @@
 /* eslint-disable no-extra-semi */
 /* eslint-disable no-case-declarations */
 /* eslint-disable prefer-const */
-import type { Spiceflow } from '../spiceflow.js'
+import type { Spiceflow } from '../spiceflow.ts'
 import superjson from 'superjson'
 import { EventSourceParserStream } from 'eventsource-parser/stream'
 
-import type { SpiceflowClient } from './types.js'
+import type { SpiceflowClient } from './types.ts'
 
 export { SpiceflowClient }
 
-import { SpiceflowFetchError } from './errors.js'
+import { SpiceflowFetchError } from './errors.ts'
 
-import { parseStringifiedValue } from './utils.js'
+import { parseStringifiedValue } from './utils.ts'
 
 const method = [
   'get',

--- a/spiceflow/src/client/types.ts
+++ b/spiceflow/src/client/types.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
-import type { Spiceflow } from '../spiceflow.js'
+import type { Spiceflow } from '../spiceflow.ts'
 
-import { SpiceflowFetchError } from './errors.js'
+import { SpiceflowFetchError } from './errors.ts'
 
 export type Prettify<T> = {
   [K in keyof T]: T[K]

--- a/spiceflow/src/context.ts
+++ b/spiceflow/src/context.ts
@@ -2,7 +2,7 @@ import type {
   StatusMap,
   InvertedStatusMap,
   redirect as Redirect,
-} from './utils.js'
+} from './utils.ts'
 
 import type {
   RouteSchema,
@@ -10,9 +10,9 @@ import type {
   ResolvePath,
   SingletonBase,
   HTTPHeaders,
-} from './types.js'
+} from './types.ts'
 
-import { SpiceflowRequest } from './spiceflow.js'
+import { SpiceflowRequest } from './spiceflow.ts'
 
 export type ErrorContext<
   in out Route extends RouteSchema = {},

--- a/spiceflow/src/cors.test.ts
+++ b/spiceflow/src/cors.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { z } from 'zod'
-import { cors } from './cors.js'
-import { Spiceflow } from './spiceflow.js'
+import { cors } from './cors.ts'
+import { Spiceflow } from './spiceflow.ts'
 
 function request(path, method = 'GET') {
   return new Request(`http://localhost/${path}`, {

--- a/spiceflow/src/cors.ts
+++ b/spiceflow/src/cors.ts
@@ -1,4 +1,4 @@
-import { MiddlewareHandler } from './types.js'
+import { MiddlewareHandler } from './types.ts'
 /**
  * Options for configuring CORS (Cross-Origin Resource Sharing) middleware.
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS MDN CORS documentation}

--- a/spiceflow/src/index.ts
+++ b/spiceflow/src/index.ts
@@ -1,3 +1,3 @@
-export { Spiceflow } from './spiceflow.js'
-export type { AnySpiceflow } from './spiceflow.js'
-export { InternalServerError, ParseError, ValidationError } from './error.js'
+export { Spiceflow } from './spiceflow.ts'
+export type { AnySpiceflow } from './spiceflow.ts'
+export { InternalServerError, ParseError, ValidationError } from './error.ts'

--- a/spiceflow/src/mcp-transport.ts
+++ b/spiceflow/src/mcp-transport.ts
@@ -1,5 +1,5 @@
 // https://github.com/modelcontextprotocol/typescript-sdk/blob/3164da64d085ec4e022ae881329eee7b72f208d4/src/server/sse.ts
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.ts'
 import {
   JSONRPCMessage,
   JSONRPCMessageSchema,

--- a/spiceflow/src/mcp.test.ts
+++ b/spiceflow/src/mcp.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest'
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { mcp } from './mcp.js'
+import { mcp } from './mcp.ts'
 
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import {
@@ -11,7 +11,7 @@ import {
   ReadResourceResultSchema,
 } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
-import { Spiceflow } from './spiceflow.js'
+import { Spiceflow } from './spiceflow.ts'
 
 describe('MCP Plugin', () => {
   let app: Spiceflow<any>

--- a/spiceflow/src/mcp.ts
+++ b/spiceflow/src/mcp.ts
@@ -7,9 +7,9 @@ import {
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
 import { OpenAPIV3 } from 'openapi-types'
-import { SSEServerTransportSpiceflow } from './mcp-transport.js'
-import { openapi } from './openapi.js'
-import { Spiceflow } from './spiceflow.js'
+import { SSEServerTransportSpiceflow } from './mcp-transport.ts'
+import { openapi } from './openapi.ts'
+import { Spiceflow } from './spiceflow.ts'
 
 const transports = new Map<string, SSEServerTransportSpiceflow>()
 function getOperationRequestBody(

--- a/spiceflow/src/middleware.test.ts
+++ b/spiceflow/src/middleware.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { z } from 'zod'
-import { Spiceflow } from './spiceflow.js'
+import { Spiceflow } from './spiceflow.ts'
 
 test('middleware with next changes the response', async () => {
   const res = await new Spiceflow()

--- a/spiceflow/src/openapi.test.ts
+++ b/spiceflow/src/openapi.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
-import { Spiceflow } from './spiceflow.js'
-import { openapi } from './openapi.js'
+import { Spiceflow } from './spiceflow.ts'
+import { openapi } from './openapi.ts'
 import { z } from 'zod'
 
 test('openapi response', async () => {

--- a/spiceflow/src/openapi.ts
+++ b/spiceflow/src/openapi.ts
@@ -1,10 +1,10 @@
-import { InternalRoute, isZodSchema, Spiceflow } from './spiceflow.js'
+import { InternalRoute, isZodSchema, Spiceflow } from './spiceflow.ts'
 
 import type { OpenAPIV3 } from 'openapi-types'
 
 let excludeMethods = ['OPTIONS']
 
-import type { TypeSchema } from './types.js'
+import type { TypeSchema } from './types.ts'
 
 import { z } from 'zod'
 import { zodToJsonSchema } from 'zod-to-json-schema'

--- a/spiceflow/src/simple.benchmark.ts
+++ b/spiceflow/src/simple.benchmark.ts
@@ -1,6 +1,6 @@
 import { bench } from 'vitest'
 
-import { Spiceflow } from './spiceflow.js'
+import { Spiceflow } from './spiceflow.ts'
 
 bench('Spiceflow basic routing', async () => {
   const app = new Spiceflow()

--- a/spiceflow/src/spiceflow.test.ts
+++ b/spiceflow/src/spiceflow.test.ts
@@ -1,8 +1,8 @@
 import { test, describe, expect } from 'vitest'
 
-import { bfs, cloneDeep, Spiceflow } from './spiceflow.js'
+import { bfs, cloneDeep, Spiceflow } from './spiceflow.ts'
 import { z } from 'zod'
-import { createSpiceflowClient } from './client/index.js'
+import { createSpiceflowClient } from './client/index.ts'
 
 test('works', async () => {
   const res = await new Spiceflow()

--- a/spiceflow/src/spiceflow.ts
+++ b/spiceflow/src/spiceflow.ts
@@ -23,15 +23,15 @@ import {
   SingletonBase,
   TypeSchema,
   UnwrapRoute,
-} from './types.js'
+} from './types.ts'
 
 import OriginalRouter from '@medley/router'
 import { type IncomingMessage, type ServerResponse } from 'http'
 import { z, ZodType } from 'zod'
 
-import { MiddlewareContext } from './context.js'
-import { isProduction, ValidationError } from './error.js'
-import { isAsyncIterable, isResponse, redirect } from './utils.js'
+import { MiddlewareContext } from './context.ts'
+import { isProduction, ValidationError } from './error.ts'
+import { isAsyncIterable, isResponse, redirect } from './utils.ts'
 import { StandardSchemaV1 } from '@standard-schema/spec'
 let globalIndex = 0
 

--- a/spiceflow/src/static-node.ts
+++ b/spiceflow/src/static-node.ts
@@ -1,7 +1,7 @@
 import { stat } from 'fs/promises'
 import fs from 'fs'
-import { ServeStaticOptions, serveStatic as baseServeStatic } from './static.js'
-import { MiddlewareHandler } from './types.js'
+import { ServeStaticOptions, serveStatic as baseServeStatic } from './static.ts'
+import { MiddlewareHandler } from './types.ts'
 
 export const serveStatic = (options: ServeStaticOptions): MiddlewareHandler => {
   const getContent = (path: string) => {

--- a/spiceflow/src/static.benchmark.ts
+++ b/spiceflow/src/static.benchmark.ts
@@ -1,7 +1,7 @@
 import { bench } from 'vitest'
 
-import { Spiceflow } from './spiceflow.js'
-import { serveStatic } from './static-node.js'
+import { Spiceflow } from './spiceflow.ts'
+import { serveStatic } from './static-node.ts'
 
 bench('Spiceflow static', async () => {
   const app = new Spiceflow()

--- a/spiceflow/src/static.ts
+++ b/spiceflow/src/static.ts
@@ -1,5 +1,5 @@
-import { MiddlewareHandler } from './types.js'
-import { isResponse } from './utils.js'
+import { MiddlewareHandler } from './types.ts'
+import { isResponse } from './utils.ts'
 
 type Env = {}
 type Context<E extends Env = Env> = {}

--- a/spiceflow/src/stream.test.ts
+++ b/spiceflow/src/stream.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest'
 
 import { createParser } from 'eventsource-parser'
 
-import { Spiceflow } from './spiceflow.js'
+import { Spiceflow } from './spiceflow.ts'
 
-import { req, sleep } from './utils.js'
+import { req, sleep } from './utils.ts'
 
 function textEventStream(items: string[]) {
   return items

--- a/spiceflow/src/types.test.ts
+++ b/spiceflow/src/types.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest'
-import { createSpiceflowClient } from './client/index.js'
-import { Spiceflow } from './spiceflow.js'
-import { Prettify } from './types.js'
+import { createSpiceflowClient } from './client/index.ts'
+import { Spiceflow } from './spiceflow.ts'
+import { Prettify } from './types.ts'
 
 test('`use` on non Spiceflow return', async () => {
   function nonSpiceflowReturn() {

--- a/spiceflow/src/types.ts
+++ b/spiceflow/src/types.ts
@@ -6,14 +6,14 @@ import { StandardSchemaV1 } from '@standard-schema/spec'
 import type { OpenAPIV3 } from 'openapi-types'
 
 import { ZodObject, ZodTypeAny } from 'zod'
-import type { Context, ErrorContext, MiddlewareContext } from './context.js'
+import type { Context, ErrorContext, MiddlewareContext } from './context.ts'
 import {
   SPICEFLOW_RESPONSE,
   InternalServerError,
   ParseError,
   ValidationError,
-} from './error.js'
-import { Spiceflow } from './spiceflow.js'
+} from './error.ts'
+import { Spiceflow } from './spiceflow.ts'
 
 export type MaybeArray<T> = T | T[]
 export type MaybePromise<T> = T | Promise<T>

--- a/spiceflow/src/zod.test.ts
+++ b/spiceflow/src/zod.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest'
 import { z } from 'zod'
-import { Spiceflow } from './spiceflow.js'
-import { req } from './utils.js'
+import { Spiceflow } from './spiceflow.ts'
+import { req } from './utils.ts'
 
 test('body is parsed as json', async () => {
   let name = ''

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,8 @@
     "module": "commonjs",
     "allowJs": true,
     "moduleResolution": "Node",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
     "lib": ["es2022", "es2017", "es7", "es6", "dom", "ESNext"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Since TypeScript 5.7, one can use the configuration flags `--allowImportingTsExtensions` and `--rewriteRelativeImportExtensions` to import files with a `.ts` extension. The output files still have imports with `.js` extension, so this is transparent for the end user.

Doing so makes it easier to run code without a build step, with Deno, Bun, tsx and the like, as well as publishing on JSR if we so choose.

Contributes to #9.