### PR TITLE
Fix type of use's handler to take full Singleton

### DIFF
--- a/spiceflow/src/spiceflow.ts
+++ b/spiceflow/src/spiceflow.ts
@@ -673,12 +673,7 @@ export class Spiceflow<
           : Routes & CreateClient<BasePath, NewSpiceflow['_routes']>
       >
   use<const Schema extends RouteSchema>(
-    handler: MiddlewareHandler<
-      Schema,
-      {
-        state: Singleton['state']
-      }
-    >,
+    handler: MiddlewareHandler<Schema, Singleton>,
   ): this
 
   use(appOrHandler) {


### PR DESCRIPTION
The type of the `handler` passed to `use` was plucking the `state` key from `Singleton`, but the implementation actually passes down the full context. It is thus more correct to use the full singleton as type parameter.

This change is useful for users that extend the singleton outside of `state`.