### PR TITLE
Fix onError by only accepting a single handler

### DIFF
--- a/spiceflow/src/spiceflow.ts
+++ b/spiceflow/src/spiceflow.ts
@@ -687,7 +687,7 @@ export class Spiceflow<
   }
 
   onError<const Schema extends RouteSchema>(
-    handler: MaybeArray<ErrorHandler<Definitions['error'], Schema, Singleton>>,
+    handler: ErrorHandler<Definitions['error'], Schema, Singleton>,
   ): this {
     this.onErrorHandlers ??= []
     this.onErrorHandlers.push(handler as any)


### PR DESCRIPTION
The types suggested that one could pass an array on handlers to `onError`. This actually does not work because the arrays are not flatten, so it immediately crashes if any error is raised.

The fix here consists of only accepting a single handler. If multiple handlers are needed, `onError` methods can be chained.