### PR TITLE
feat: add type-safe safePath method

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,4 +33,5 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
+          allowed_tools: 'Bash'
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/e2e/src/mcp.test.ts
+++ b/e2e/src/mcp.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest'
 
-import { Spiceflow } from 'spiceflow'
+import { AnySpiceflow, Spiceflow } from 'spiceflow'
 import { mcp } from 'spiceflow/mcp'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
@@ -14,7 +14,7 @@ import { z } from 'zod'
 import { getAvailablePort } from './get-available-port.ts'
 
 describe('MCP Plugin', () => {
-  let app: Spiceflow<any>
+  let app: AnySpiceflow
   let port: number
   let client: Client
   let transport: SSEClientTransport

--- a/spiceflow/src/_node-server.ts
+++ b/spiceflow/src/_node-server.ts
@@ -5,11 +5,11 @@ import {
   createServer,
 } from 'node:http'
 import { AddressInfo } from 'node:net'
-import { type Spiceflow, SpiceflowRequest } from './spiceflow.ts'
+import { AnySpiceflow, type Spiceflow, SpiceflowRequest } from './spiceflow.ts'
 import { superjsonSerialize } from './serialize.ts'
 
 export async function listenForNode(
-  app: Spiceflow<any, any, any, any, any, any>,
+  app: AnySpiceflow,
   port: number,
   hostname: string = '0.0.0.0',
 ): Promise<Server<typeof IncomingMessage, typeof ServerResponse>> {
@@ -33,7 +33,7 @@ export async function listenForNode(
 }
 
 export async function handleForNode(
-  app: Spiceflow<any, any, any, any, any, any>,
+  app: AnySpiceflow,
   req: IncomingMessage,
   res: ServerResponse,
   context: { state?: {} | undefined } = {},

--- a/spiceflow/src/client/index.ts
+++ b/spiceflow/src/client/index.ts
@@ -1,4 +1,4 @@
-import type { Spiceflow } from '../spiceflow.ts'
+import type { AnySpiceflow, Spiceflow } from '../spiceflow.ts'
 import superjson from 'superjson'
 import { EventSourceParserStream } from 'eventsource-parser/stream'
 
@@ -179,7 +179,7 @@ const createProxy = (
   domain: string,
   config: SpiceflowClient.Config & { state?: any },
   paths: string[] = [],
-  instance?: Spiceflow<any, any, any, any, any, any>,
+  instance?: AnySpiceflow,
 ): any => {
   if (config.state && !instance) {
     throw new Error(`State is only available when using a Spiceflow instance`)
@@ -464,11 +464,11 @@ const createProxy = (
 }
 
 export const createSpiceflowClient = <
-  const App extends Spiceflow<any, any, any, any, any, any>,
+  const App extends AnySpiceflow,
 >(
   domain: App | string,
   config?: SpiceflowClient.Config &
-    (App extends Spiceflow<any, any, infer Singleton, any, any, any>
+    (App extends Spiceflow<any, any, infer Singleton, any, any, any, any>
       ? { state?: Singleton['state'] }
       : {}),
 ): SpiceflowClient.Create<App> => {

--- a/spiceflow/src/client/types.ts
+++ b/spiceflow/src/client/types.ts
@@ -56,12 +56,11 @@ export namespace SpiceflowClient {
     fetch?: RequestInit
   }
 
-  export type Create<App extends AnySpiceflow> =
-    App extends {
-      _routes: infer Schema extends Record<string, any>
-    }
-      ? Prettify<Sign<Schema>>
-      : 'Please install Spiceflow before using the client'
+  export type Create<App extends AnySpiceflow> = App extends {
+    _types: { ClientRoutes: infer Schema extends Record<string, any> }
+  }
+    ? Prettify<Sign<Schema>>
+    : 'Please install latest Spiceflow before using the client, also make sure both client and server use the same version'
 
   export type Sign<in out Route extends Record<string, any>> = {
     [K in keyof Route as K extends `:${string}` ? never : K]: Route[K] extends {

--- a/spiceflow/src/client/types.ts
+++ b/spiceflow/src/client/types.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import type { Spiceflow } from '../spiceflow.ts'
+import type { AnySpiceflow, Spiceflow } from '../spiceflow.ts'
 
 import { SpiceflowFetchError } from './errors.ts'
 
@@ -56,7 +56,7 @@ export namespace SpiceflowClient {
     fetch?: RequestInit
   }
 
-  export type Create<App extends Spiceflow<any, any, any, any, any, any>> =
+  export type Create<App extends AnySpiceflow> =
     App extends {
       _routes: infer Schema extends Record<string, any>
     }

--- a/spiceflow/src/spiceflow.test.ts
+++ b/spiceflow/src/spiceflow.test.ts
@@ -863,10 +863,16 @@ describe('safePath', () => {
       .get('/posts/:postId/comments/:commentId', ({ params }) => params)
 
     expect(app.safePath('/users/:id', { id: '123' })).toBe('/users/123')
-    expect(app.safePath('/posts/:postId/comments/:commentId', { 
-      postId: 'abc', 
-      commentId: '456' 
-    })).toBe('/posts/abc/comments/456')
+    // @ts-expect-error
+    app.safePath('/nonusers/:id', { id: '123' })
+    // @ts-expect-error
+    app.safePath('/users/:nonid', { nonid: '123' })
+    expect(
+      app.safePath('/posts/:postId/comments/:commentId', {
+        postId: 'abc',
+        commentId: '456',
+      }),
+    ).toBe('/posts/abc/comments/456')
   })
 
   test('handles paths with optional parameters', () => {
@@ -876,42 +882,50 @@ describe('safePath', () => {
 
     expect(app.safePath('/users/:id?', { id: '123' })).toBe('/users/123')
     expect(app.safePath('/users/:id?', {})).toBe('/users/')
-    expect(app.safePath('/posts/:postId/comments/:commentId?', { 
-      postId: 'abc', 
-      commentId: '456' 
-    })).toBe('/posts/abc/comments/456')
-    expect(app.safePath('/posts/:postId/comments/:commentId?', { 
-      postId: 'abc' 
-    })).toBe('/posts/abc/comments/')
+    expect(
+      app.safePath('/posts/:postId/comments/:commentId?', {
+        postId: 'abc',
+        commentId: '456',
+      }),
+    ).toBe('/posts/abc/comments/456')
+    expect(
+      app.safePath('/posts/:postId/comments/:commentId?', {
+        postId: 'abc',
+      }),
+    ).toBe('/posts/abc/comments/')
   })
 
   test('handles mixed required and optional parameters', () => {
-    const app = new Spiceflow()
-      .get('/api/:version/users/:id/posts/:postId?', ({ params }) => params)
+    const app = new Spiceflow().get(
+      '/api/:version/users/:id/posts/:postId?',
+      ({ params }) => params,
+    )
 
-    expect(app.safePath('/api/:version/users/:id/posts/:postId?', {
-      version: 'v1',
-      id: '123',
-      postId: 'abc'
-    })).toBe('/api/v1/users/123/posts/abc')
+    expect(
+      app.safePath('/api/:version/users/:id/posts/:postId?', {
+        version: 'v1',
+        id: '123',
+        postId: 'abc',
+      }),
+    ).toBe('/api/v1/users/123/posts/abc')
 
-    expect(app.safePath('/api/:version/users/:id/posts/:postId?', {
-      version: 'v1',
-      id: '123'
-    })).toBe('/api/v1/users/123/posts/')
+    expect(
+      app.safePath('/api/:version/users/:id/posts/:postId?', {
+        version: 'v1',
+        id: '123',
+      }),
+    ).toBe('/api/v1/users/123/posts/')
   })
 
   test('handles numeric parameter values', () => {
-    const app = new Spiceflow()
-      .get('/users/:id', ({ params }) => params.id)
+    const app = new Spiceflow().get('/users/:id', ({ params }) => params.id)
 
-    expect(app.safePath('/users/:id', { id: 123 })).toBe('/users/123')
-    expect(app.safePath('/users/:id', { id: 0 })).toBe('/users/0')
+    expect(app.safePath('/users/:id', { id: '123' })).toBe('/users/123')
+    expect(app.safePath('/users/:id', { id: '0' })).toBe('/users/0')
   })
 
   test('handles empty parameters object', () => {
-    const app = new Spiceflow()
-      .get('/static', () => 'static')
+    const app = new Spiceflow().get('/static', () => 'static')
 
     expect(app.safePath('/static', {})).toBe('/static')
   })

--- a/spiceflow/src/spiceflow.ts
+++ b/spiceflow/src/spiceflow.ts
@@ -2,27 +2,27 @@ import lodashCloneDeep from 'lodash.clonedeep'
 import { SpiceflowFetchError } from './client/errors.ts'
 import { ValidationError } from './error.ts'
 import {
-    ComposeSpiceflowResponse,
-    ContentType,
-    CreateClient,
-    DefinitionBase,
-    ErrorHandler,
-    ExtractParamsFromPath,
-    HTTPMethod,
-    InlineHandler,
-    InputSchema,
-    IsAny,
-    JoinPath,
-    LocalHook,
-    MetadataBase,
-    MiddlewareHandler,
-    Reconcile,
-    ResolvePath,
-    RouteBase,
-    RouteSchema,
-    SingletonBase,
-    TypeSchema,
-    UnwrapRoute
+  ComposeSpiceflowResponse,
+  ContentType,
+  CreateClient,
+  DefinitionBase,
+  ErrorHandler,
+  ExtractParamsFromPath,
+  HTTPMethod,
+  InlineHandler,
+  InputSchema,
+  IsAny,
+  JoinPath,
+  LocalHook,
+  MetadataBase,
+  MiddlewareHandler,
+  Reconcile,
+  ResolvePath,
+  RouteBase,
+  RouteSchema,
+  SingletonBase,
+  TypeSchema,
+  UnwrapRoute,
 } from './types.ts'
 
 import OriginalRouter from '@medley/router'
@@ -93,7 +93,7 @@ export class Spiceflow<
     macro: {}
     macroFn: {}
   },
-  const out Routes extends RouteBase = {},
+  const out ClientRoutes extends RouteBase = {},
   const out RoutePaths extends string = '',
 > {
   private id: number = globalIndex++
@@ -103,11 +103,11 @@ export class Spiceflow<
   private routes: InternalRoute[] = []
   private defaultState: Record<any, any> = {}
   topLevelApp?: AnySpiceflow
-  _routes: Routes = {} as any
 
   _types = {
     Prefix: '' as BasePath,
-    _pathsType: '' as RoutePaths,
+    ClientRoutes: {} as ClientRoutes,
+    RoutePaths: '' as RoutePaths,
     Scoped: false as Scoped,
     Singleton: {} as Singleton,
     Definitions: {} as Definitions,
@@ -266,7 +266,7 @@ export class Spiceflow<
     },
     Definitions,
     Metadata,
-    Routes,
+    ClientRoutes,
     RoutePaths
   > {
     this.defaultState[name] = value
@@ -316,7 +316,7 @@ export class Spiceflow<
     Singleton,
     Definitions,
     Metadata,
-    Routes &
+    ClientRoutes &
       CreateClient<
         JoinPath<BasePath, Path>,
         {
@@ -364,7 +364,7 @@ export class Spiceflow<
     Singleton,
     Definitions,
     Metadata,
-    Routes &
+    ClientRoutes &
       CreateClient<
         JoinPath<BasePath, Path>,
         {
@@ -411,7 +411,7 @@ export class Spiceflow<
     Singleton,
     Definitions,
     Metadata,
-    Routes &
+    ClientRoutes &
       CreateClient<
         JoinPath<BasePath, Path>,
         {
@@ -459,7 +459,7 @@ export class Spiceflow<
     Singleton,
     Definitions,
     Metadata,
-    Routes &
+    ClientRoutes &
       CreateClient<
         JoinPath<BasePath, Path>,
         {
@@ -507,7 +507,7 @@ export class Spiceflow<
     Singleton,
     Definitions,
     Metadata,
-    Routes &
+    ClientRoutes &
       CreateClient<
         JoinPath<BasePath, Path>,
         {
@@ -555,7 +555,7 @@ export class Spiceflow<
     Singleton,
     Definitions,
     Metadata,
-    Routes &
+    ClientRoutes &
       CreateClient<
         JoinPath<BasePath, Path>,
         {
@@ -603,7 +603,7 @@ export class Spiceflow<
     Singleton,
     Definitions,
     Metadata,
-    Routes &
+    ClientRoutes &
       CreateClient<
         JoinPath<BasePath, Path>,
         {
@@ -653,7 +653,7 @@ export class Spiceflow<
     Singleton,
     Definitions,
     Metadata,
-    Routes &
+    ClientRoutes &
       CreateClient<
         JoinPath<BasePath, Path>,
         {
@@ -688,9 +688,10 @@ export class Spiceflow<
         Definitions,
         Metadata,
         BasePath extends ``
-          ? Routes & NewSpiceflow['_routes']
-          : Routes & CreateClient<BasePath, NewSpiceflow['_routes']>,
-        RoutePaths | NewSpiceflow['_types']['_pathsType']
+          ? ClientRoutes & NewSpiceflow['_types']['ClientRoutes']
+          : ClientRoutes &
+              CreateClient<BasePath, NewSpiceflow['_types']['ClientRoutes']>,
+        RoutePaths | NewSpiceflow['_types']['RoutePaths']
       >
   use<const Schema extends RouteSchema>(
     handler: MiddlewareHandler<Schema, Singleton>,

--- a/spiceflow/src/spiceflow.ts
+++ b/spiceflow/src/spiceflow.ts
@@ -7,6 +7,8 @@ import {
   CreateClient,
   DefinitionBase,
   ErrorHandler,
+  ExtractParamsFromPath,
+  GetPathsFromRoutes,
   HTTPMethod,
   InlineHandler,
   InputSchema,
@@ -1089,6 +1091,31 @@ export class Spiceflow<
         },
       },
     )
+  }
+
+  safePath<
+    const Path extends GetPathsFromRoutes<Routes>,
+    const Params extends ExtractParamsFromPath<Path>
+  >(
+    path: Path,
+    params: Params
+  ): string {
+    let result = path as string
+    
+    // First, handle all provided parameters
+    if (params && typeof params === 'object') {
+      Object.entries(params).forEach(([key, value]) => {
+        // Handle both required (:key) and optional (:key?) parameters
+        const regex = new RegExp(`:${key}\\??`, 'g')
+        result = result.replace(regex, String(value))
+      })
+    }
+    
+    // Then, handle any remaining optional parameters that weren't provided
+    // Replace any remaining :param? with empty string (keeping trailing slash)
+    result = result.replace(/:[\w-]+\?/g, '')
+    
+    return result
   }
 }
 

--- a/spiceflow/src/spiceflow.ts
+++ b/spiceflow/src/spiceflow.ts
@@ -1,30 +1,28 @@
 import lodashCloneDeep from 'lodash.clonedeep'
-import { ValidationError } from './error.ts'
 import { SpiceflowFetchError } from './client/errors.ts'
+import { ValidationError } from './error.ts'
 import {
-  ComposeSpiceflowResponse,
-  ContentType,
-  CreateClient,
-  DefinitionBase,
-  ErrorHandler,
-  ExtractParamsFromPath,
-  GetPathsFromRoutes,
-  HTTPMethod,
-  InlineHandler,
-  InputSchema,
-  IsAny,
-  JoinPath,
-  LocalHook,
-  MetadataBase,
-  MiddlewareHandler,
-  Reconcile,
-  ReconstructPath,
-  ResolvePath,
-  RouteBase,
-  RouteSchema,
-  SingletonBase,
-  TypeSchema,
-  UnwrapRoute,
+    ComposeSpiceflowResponse,
+    ContentType,
+    CreateClient,
+    DefinitionBase,
+    ErrorHandler,
+    ExtractParamsFromPath,
+    HTTPMethod,
+    InlineHandler,
+    InputSchema,
+    IsAny,
+    JoinPath,
+    LocalHook,
+    MetadataBase,
+    MiddlewareHandler,
+    Reconcile,
+    ResolvePath,
+    RouteBase,
+    RouteSchema,
+    SingletonBase,
+    TypeSchema,
+    UnwrapRoute
 } from './types.ts'
 
 import OriginalRouter from '@medley/router'
@@ -106,9 +104,10 @@ export class Spiceflow<
   private defaultState: Record<any, any> = {}
   topLevelApp?: AnySpiceflow
   _routes: Routes = {} as any
-  _pathsType: RoutePaths = '' as any
+
   _types = {
     Prefix: '' as BasePath,
+    _pathsType: '' as RoutePaths,
     Scoped: false as Scoped,
     Singleton: {} as Singleton,
     Definitions: {} as Definitions,
@@ -691,7 +690,7 @@ export class Spiceflow<
         BasePath extends ``
           ? Routes & NewSpiceflow['_routes']
           : Routes & CreateClient<BasePath, NewSpiceflow['_routes']>,
-        RoutePaths | NewSpiceflow['_pathsType']
+        RoutePaths | NewSpiceflow['_types']['_pathsType']
       >
   use<const Schema extends RouteSchema>(
     handler: MiddlewareHandler<Schema, Singleton>,

--- a/spiceflow/src/types.ts
+++ b/spiceflow/src/types.ts
@@ -673,8 +673,8 @@ export type MergeSpiceflowInstances<
         Metadata & Current['_types']['Metadata'],
         Routes &
           (Prefix extends ``
-            ? Current['_routes']
-            : AddPrefix<Prefix, Current['_routes']>)
+            ? Current['_types']['ClientRoutes']
+            : AddPrefix<Prefix, Current['_types']['ClientRoutes']>)
       >
   : Spiceflow<
       Prefix,

--- a/spiceflow/src/types.ts
+++ b/spiceflow/src/types.ts
@@ -851,3 +851,21 @@ export type JoinPath<A extends string, B extends string> = `${A}${B extends '/'
 
 export type PartialWithRequired<T, K extends keyof T> = Partial<Omit<T, K>> &
   Pick<T, K>
+
+export type GetPathsFromRoutes<Routes> = 
+  Routes extends Record<infer K, any> 
+    ? K extends string 
+      ? K 
+      : never 
+    : never
+
+export type ExtractParamsFromPath<Path extends string> = 
+  Path extends `${string}:${infer Param}/${infer Rest}`
+    ? Param extends `${infer Name}?`
+      ? { [K in Name]?: string } & ExtractParamsFromPath<`/${Rest}`>
+      : { [K in Param]: string } & ExtractParamsFromPath<`/${Rest}`>
+    : Path extends `${string}:${infer Param}`
+      ? Param extends `${infer Name}?`
+        ? { [K in Name]?: string }
+        : { [K in Param]: string }
+      : {}

--- a/spiceflow/src/types.ts
+++ b/spiceflow/src/types.ts
@@ -8,7 +8,7 @@ import type { OpenAPIV3 } from 'openapi-types'
 import { ZodTypeAny } from 'zod'
 import type { Context, ErrorContext, MiddlewareContext } from './context.ts'
 import { SPICEFLOW_RESPONSE, ValidationError } from './error.ts'
-import { Spiceflow } from './spiceflow.ts'
+import { AnySpiceflow, Spiceflow } from './spiceflow.ts'
 
 export type MaybeArray<T> = T | T[]
 export type MaybePromise<T> = T | Promise<T>
@@ -634,7 +634,7 @@ type _ComposeSpiceflowResponse<Response, Handle> = Prettify<
 >
 
 export type MergeSpiceflowInstances<
-  Instances extends Spiceflow<any, any, any, any, any, any>[] = [],
+  Instances extends AnySpiceflow[] = [],
   Prefix extends string = '',
   Scoped extends boolean = false,
   Singleton extends SingletonBase = {
@@ -651,8 +651,8 @@ export type MergeSpiceflowInstances<
   },
   Routes extends RouteBase = {},
 > = Instances extends [
-  infer Current extends Spiceflow<any, any, any, any, any, any>,
-  ...infer Rest extends Spiceflow<any, any, any, any, any, any>[],
+  infer Current extends AnySpiceflow,
+  ...infer Rest extends AnySpiceflow[],
 ]
   ? Current['_types']['Scoped'] extends true
     ? MergeSpiceflowInstances<
@@ -852,14 +852,10 @@ export type JoinPath<A extends string, B extends string> = `${A}${B extends '/'
 export type PartialWithRequired<T, K extends keyof T> = Partial<Omit<T, K>> &
   Pick<T, K>
 
-export type GetPathsFromRoutes<Routes> = 
-  Routes extends Record<infer K, any> 
-    ? K extends string 
-      ? K 
-      : never 
-    : never
+export type GetPathsFromRoutes<Routes extends Record<string, unknown>> =
+  Routes extends Record<infer K, any> ? (K extends string ? K : never) : never
 
-export type ExtractParamsFromPath<Path extends string> = 
+export type ExtractParamsFromPath<Path extends string> =
   Path extends `${string}:${infer Param}/${infer Rest}`
     ? Param extends `${infer Name}?`
       ? { [K in Name]?: string } & ExtractParamsFromPath<`/${Rest}`>


### PR DESCRIPTION
Implements type-safe safePath method for issue #25

## Summary
- Added `safePath` method to Spiceflow class with 2 arguments (path string, params object)
- Full TypeScript type safety with compile-time validation of paths and parameters
- Support for both required (`:id`) and optional (`:id?`) parameters
- Comprehensive vitest test suite with 6 test cases covering all scenarios

## Usage
```typescript
const app = new Spiceflow()
  .get('/users/:id', ({ params }) => params.id)

const userUrl = app.safePath('/users/:id', { id: '123' })  // '/users/123'
```

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)