### PR TITLE
Remove :param? optional parameter handling from safePath and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ const app = new Spiceflow()
   })
   .route({
     method: 'GET',
-    path: '/users/:id/posts/:postId?',
+    path: '/users/:id/posts/:postId',
     handler({ params }) {
       return { userId: params.id, postId: params.postId }
     },
@@ -262,18 +262,12 @@ const app = new Spiceflow()
 const userPath = app.safePath('/users/:id', { id: '123' })
 // Result: '/users/123'
 
-// Building URLs with optional parameters
-const userPostPath = app.safePath('/users/:id/posts/:postId?', {
+// Building URLs with required parameters
+const userPostPath = app.safePath('/users/:id/posts/:postId', {
   id: '456',
   postId: 'abc'
 })
 // Result: '/users/456/posts/abc'
-
-// Optional parameters can be omitted
-const userPostsPath = app.safePath('/users/:id/posts/:postId?', {
-  id: '456'
-})
-// Result: '/users/456/posts/'
 ```
 
 ### OAuth Callback Example
@@ -286,7 +280,7 @@ import { Spiceflow } from 'spiceflow'
 const app = new Spiceflow()
   .route({
     method: 'GET',
-    path: '/auth/callback/:provider/:userId?',
+    path: '/auth/callback/:provider/:userId',
     handler({ params, query }) {
       const { provider, userId } = params
       const { code, state } = query
@@ -309,7 +303,7 @@ const app = new Spiceflow()
       
       // Build the OAuth callback URL safely
       const callbackUrl = new URL(
-        app.safePath('/auth/callback/:provider/:userId?', {
+        app.safePath('/auth/callback/:provider/:userId', {
           provider,
           userId
         }),
@@ -330,8 +324,7 @@ const app = new Spiceflow()
 
 In this example:
 - The callback URL is built safely using `safePath` with type checking
-- Required parameters like `provider` must be provided
-- Optional parameters like `userId` can be included or omitted
+- Required parameters like `provider` and `userId` must be provided
 - The resulting URL is guaranteed to be properly formatted
 
 ## Mounting Sub-Apps

--- a/spiceflow/src/client.test.ts
+++ b/spiceflow/src/client.test.ts
@@ -120,7 +120,7 @@ const app = new Spiceflow()
   .get('/stream-return-async', function* stream() {
     return 'a'
   })
-  .get('/id/:id?', ({ params: { id = 'unknown' } }) => id)
+  .get('/id/:id', ({ params: { id } }) => id)
 
 const client = createSpiceflowClient(app)
 

--- a/spiceflow/src/spiceflow.test.ts
+++ b/spiceflow/src/spiceflow.test.ts
@@ -904,47 +904,7 @@ describe('safePath', () => {
     ).toBe('/posts/abc/comments/456')
   })
 
-  test('handles paths with optional parameters', () => {
-    const app = new Spiceflow()
-      .get('/users/:id?', ({ params }) => params.id)
-      .get('/posts/:postId/comments/:commentId?', ({ params }) => params)
 
-    expect(app.safePath('/users/:id?', { id: '123' })).toBe('/users/123')
-    expect(app.safePath('/users/:id?', {})).toBe('/users/')
-    expect(
-      app.safePath('/posts/:postId/comments/:commentId?', {
-        postId: 'abc',
-        commentId: '456',
-      }),
-    ).toBe('/posts/abc/comments/456')
-    expect(
-      app.safePath('/posts/:postId/comments/:commentId?', {
-        postId: 'abc',
-      }),
-    ).toBe('/posts/abc/comments/')
-  })
-
-  test('handles mixed required and optional parameters', () => {
-    const app = new Spiceflow().get(
-      '/api/:version/users/:id/posts/:postId?',
-      ({ params }) => params,
-    )
-
-    expect(
-      app.safePath('/api/:version/users/:id/posts/:postId?', {
-        version: 'v1',
-        id: '123',
-        postId: 'abc',
-      }),
-    ).toBe('/api/v1/users/123/posts/abc')
-
-    expect(
-      app.safePath('/api/:version/users/:id/posts/:postId?', {
-        version: 'v1',
-        id: '123',
-      }),
-    ).toBe('/api/v1/users/123/posts/')
-  })
 
   test('handles numeric parameter values', () => {
     const app = new Spiceflow().get('/users/:id', ({ params }) => params.id)

--- a/spiceflow/src/spiceflow.ts
+++ b/spiceflow/src/spiceflow.ts
@@ -1179,18 +1179,14 @@ export class Spiceflow<
   >(path: Path, params: Params): string {
     let result = path as string
 
-    // First, handle all provided parameters
+    // Handle all provided parameters
     if (params && typeof params === 'object') {
       Object.entries(params).forEach(([key, value]) => {
-        // Handle both required (:key) and optional (:key?) parameters
-        const regex = new RegExp(`:${key}\\??`, 'g')
+        // Handle required parameters only
+        const regex = new RegExp(`:${key}`, 'g')
         result = result.replace(regex, String(value))
       })
     }
-
-    // Then, handle any remaining optional parameters that weren't provided
-    // Replace any remaining :param? with empty string (keeping trailing slash)
-    result = result.replace(/:[\w-]+\?/g, '')
 
     return result
   }


### PR DESCRIPTION
Fixes #32

Removed the non-working :param? optional parameter syntax from:
- safePath method implementation
- README examples and documentation
- Test cases

All path parameters are now required, simplifying the API and removing buggy behavior.

Generated with [Claude Code](https://claude.ai/code)