### PR TITLE
fix: use MDX comments instead of HTML comments in readme script

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm --filter spiceflow build && pnpm readme && react-router build",
-    "readme": "echo '<!-- DO NOT EDIT: This file is auto-generated from root README.md -->' > ./app/routes/_mdx._index.mdx && cat ../README.md >> ./app/routes/_mdx._index.mdx",
+    "readme": "echo '{/* DO NOT EDIT: This file is auto-generated from root README.md */}' > ./app/routes/_mdx._index.mdx && cat ../README.md >> ./app/routes/_mdx._index.mdx",
     "deploy:prod": "pnpm run build && wrangler deploy ",
     "dev": "pnpm readme && react-router dev",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",


### PR DESCRIPTION
Fixes #35

Changed the readme script in website/package.json to use MDX comment format `{/* ... */}` instead of HTML comment format `<!-- ... -->` when copying README.md to the website.

This makes the comment more appropriate for .mdx files and follows JavaScript/MDChain comment conventions.

Generated with [Claude Code](https://claude.ai/code)