### PR TITLE
Add Resource Preloading section to RSC docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2535,6 +2535,81 @@ export { Map } from './map'
 
 </details>
 
+### Resource Preloading
+
+React 19 provides `preload`, `preinit`, `prefetchDNS`, and `preconnect` functions from `react-dom` that emit `<link>` tags into the SSR HTML when called during render. This lets the browser start downloading resources immediately with the initial page load, before any JavaScript executes.
+
+Call these functions in your component render body (not in effects or event handlers):
+
+```tsx
+import { preload, preinit, prefetchDNS, preconnect } from 'react-dom'
+
+function HeroSection() {
+  // Emits <link rel="preload" as="video" href="/assets/hero.mp4">
+  preload('/assets/hero.mp4', { as: 'video' })
+
+  // Emits <link rel="preload" as="image" href="/og.png">
+  preload('/og.png', { as: 'image' })
+
+  return <div>{/* ... */}</div>
+}
+```
+
+**Fonts** need `crossOrigin` set (fonts are always CORS requests):
+
+```tsx
+function Layout({ children }: { children: React.ReactNode }) {
+  // Preload font file, emits <link rel="preload" as="font" crossorigin ...>
+  preload('/fonts/Inter-Regular.woff2', {
+    as: 'font',
+    type: 'font/woff2',
+    crossOrigin: 'anonymous',
+  })
+
+  return <html>{children}</html>
+}
+```
+
+**`preinit`** goes further than `preload`; it downloads AND executes the resource (stylesheets are inserted, scripts are run):
+
+```tsx
+function Dashboard() {
+  // Download and insert this stylesheet immediately
+  preinit('/styles/dashboard.css', { as: 'style' })
+
+  // Download and execute this script immediately
+  preinit('/analytics.js', { as: 'script' })
+
+  return <div>{/* ... */}</div>
+}
+```
+
+**DNS and connection hints** for external resources:
+
+```tsx
+function App() {
+  // Resolve DNS for the API domain early
+  prefetchDNS('https://api.example.com')
+
+  // Open a connection (DNS + TCP + TLS) to the CDN
+  preconnect('https://cdn.example.com')
+
+  // preconnect without credentials (no cookies sent)
+  preconnect('https://analytics.example.com', { crossOrigin: 'anonymous' })
+
+  return <div>{/* ... */}</div>
+}
+```
+
+These calls work in both server components and client components. During SSR they emit the `<link>` tags into the HTML `<head>`. During client-side navigation they insert the tags into the live DOM. Duplicate calls with the same href are automatically deduplicated.
+
+| Function | What it does | Common use |
+|---|---|---|
+| `preload` | Download and cache (don't execute) | Videos, images, fonts, large scripts |
+| `preinit` | Download, cache, and execute | Stylesheets, analytics scripts |
+| `prefetchDNS` | Resolve DNS for a domain | API servers, third-party services |
+| `preconnect` | DNS + TCP + TLS handshake | CDNs, auth providers |
+
 ### Directory Paths
 
 > Only available when using the Vite plugin.


### PR DESCRIPTION
Documents React 19's `preload`, `preinit`, `prefetchDNS`, and `preconnect` functions from `react-dom`. These emit `<link>` tags into SSR HTML when called during component render, letting the browser start downloading resources immediately with the initial page load.

Covers: videos, images, fonts (with `crossOrigin`), stylesheets, scripts, DNS prefetch, and connection hints. Includes a summary table at the end.

Placed after Code Splitting and before Directory Paths in the RSC section.